### PR TITLE
fix filename error for luarocks make correct installation

### DIFF
--- a/kong-redis-session-0.0.1-0.rockspec
+++ b/kong-redis-session-0.0.1-0.rockspec
@@ -16,6 +16,6 @@ build = {
   modules = {
     ["kong.plugins.redis-session.handler"] = "handler.lua",
     ["kong.plugins.redis-session.schema"] = "schema.lua",
-    ["kong.plugins.redis-session.header_filter"] = "header_filter",
+    ["kong.plugins.redis-session.header_filter"] = "header_filter.lua",
   }
 }


### PR DESCRIPTION
When try to compile over "luarocks make" I got an error :
```
gcc: error: header_filter: No such file or directory
gcc: fatal error: no input files
compilation terminated.

Error: Build error: Failed compiling object header_filter
```

and fix filename for header_filter.lua for correct compile